### PR TITLE
Fix error behavior during download

### DIFF
--- a/ssds/blobstore/local.py
+++ b/ssds/blobstore/local.py
@@ -73,8 +73,9 @@ class LocalBlob(Blob):
         if self.url != src_blob.url:
             shutil.copyfile(src_blob._path, self._path)
 
-    @catch_blob_not_found
     def download(self, path: str):
+        if not os.path.isfile(self._path):
+            raise BlobNotFoundError(f"Could not find {self.key}")
         if self.url != path:
             shutil.copyfile(self._path, path)
 

--- a/ssds/blobstore/local.py
+++ b/ssds/blobstore/local.py
@@ -14,7 +14,7 @@ def catch_blob_not_found(func):
         try:
             return func(self, *args, **kwargs)
         except FileNotFoundError as ex:
-            raise BlobNotFoundError(f"Could not find {self.key}") from ex
+            raise BlobNotFoundError(f"Could not find {self.url}") from ex
     return wrapper
 
 class LocalBlobStore(BlobStore):
@@ -75,7 +75,7 @@ class LocalBlob(Blob):
 
     def download(self, path: str):
         if not os.path.isfile(self._path):
-            raise BlobNotFoundError(f"Could not find {self.key}")
+            raise BlobNotFoundError(f"Could not find {self.url}")
         if self.url != path:
             shutil.copyfile(self._path, path)
 

--- a/tests/test_blobstore.py
+++ b/tests/test_blobstore.py
@@ -82,6 +82,10 @@ class TestBlobStore(infra.SuppressWarningsMixin, unittest.TestCase):
             with self.subTest("blob not found", blobstore=bs):
                 with self.assertRaises(BlobNotFoundError):
                     bs.blob(f"{uuid4()}").download(dst_path)
+            dst_subdir_path = local_blobstore.blob(os.path.join(f"{uuid4()}", "subdirs", "dont", "exist", "foo")).url
+            with self.subTest("Subdirectories don't exist", blobstore=bs):
+                with self.assertRaises(FileNotFoundError):
+                    bs.blob(src_key).download(dst_subdir_path)
 
     def test_size(self):
         key = f"{uuid4()}"


### PR DESCRIPTION
Blobs should raise `FileNotFoundError` if download path subdirectories do not exist.