### PR TITLE
Copy client reports all failures

### DIFF
--- a/ssds/storage.py
+++ b/ssds/storage.py
@@ -3,7 +3,8 @@ Low level cloud agnostic storage API
 """
 import os
 import logging
-from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
+import traceback
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union, Callable
 
 from ssds import checksum
 from ssds.blobstore import get_s3_multipart_chunk_size, Blob
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 AnyBlobStore = Union[LocalBlobStore, S3BlobStore, GSBlobStore]
 AnyBlob = Union[LocalBlob, S3Blob, GSBlob]
 CloudBlob = Union[S3Blob, GSBlob]
+_CopyMethod = Callable[..., Optional[Dict[str, str]]]
 
 class SSDSObjectTag:
     SSDS_MD5 = "SSDS_MD5"
@@ -36,7 +38,7 @@ class CopyClient:
     def __init__(self, ignore_missing_checksums: bool=False):
         self._ignore_missing_checksums = ignore_missing_checksums
         self._async_set = async_set(10)
-        self._completed_keys: Set[str] = set()
+        self._completed: Set[Tuple[AnyBlob, AnyBlob, Optional[Exception]]] = set()
 
     def copy(self, src_blob: AnyBlob, dst_blob: AnyBlob):
         """
@@ -60,66 +62,60 @@ class CopyClient:
         Copy from `src_blob` to `dst_blob`, computing checksums
         This always causes data to pass through the executing instance.
         """
-        def _do_oneshot_copy():
-            tags = copy_oneshot_passthrough(src_blob, dst_blob, compute_checksums=True)
-            self._finalize_copy(src_blob, dst_blob, tags)
-
         size = src_blob.size()
         if size <= get_s3_multipart_chunk_size(size):
-            self._async_set.put(_do_oneshot_copy)
+            self._do_copy_async(copy_oneshot_passthrough, src_blob, dst_blob, compute_checksums=True)
         else:
-            tags = copy_multipart_passthrough(src_blob, dst_blob, compute_checksums=True)
-            self._async_set.put(self._finalize_copy, src_blob, dst_blob, tags)
+            self._do_copy(copy_multipart_passthrough, src_blob, dst_blob, compute_checksums=True)
 
     def _download(self, src_blob: AnyBlob, dst_blob: LocalBlob):
         dirname = os.path.dirname(dst_blob.url)
         if dirname:
             os.makedirs(dirname, exist_ok=True)
-
-        def do_download():
-            src_blob.download(dst_blob.url)
-            self._finalize_copy(src_blob, dst_blob)
-
-        self._async_set.put(do_download)
+        self._do_copy_async(_download_to, src_blob, dst_blob)
 
     def _copy_intra_cloud(self, src_blob: AnyBlob, dst_blob: AnyBlob):
-        assert isinstance(src_blob, type(dst_blob))
-
-        def do_oneshot_copy():
-            dst_blob.copy_from(src_blob)  # type: ignore
-            self._finalize_copy(src_blob, dst_blob)
-
         if dst_blob.copy_from_is_multipart(src_blob):  # type: ignore
-            dst_blob.copy_from(src_blob)  # type: ignore
-            self._async_set.put(self._finalize_copy, src_blob, dst_blob)
+            self._do_copy(_copy_intra_cloud, src_blob, dst_blob)
         else:
-            self._async_set.put(do_oneshot_copy)
+            self._do_copy_async(_copy_intra_cloud, src_blob, dst_blob)
 
     def _copy_oneshot(self, src_blob: AnyBlob, dst_blob: CloudBlob):
-        assert not isinstance(src_blob, type(dst_blob))
-
-        def do_copy():
-            tags = copy_oneshot_passthrough(src_blob, dst_blob, compute_checksums=isinstance(src_blob, LocalBlob))
-            self._finalize_copy(src_blob, dst_blob, tags)
-
-        self._async_set.put(do_copy)
+        self._do_copy_async(copy_oneshot_passthrough,
+                            src_blob,
+                            dst_blob,
+                            compute_checksums=isinstance(src_blob, LocalBlob))
 
     def _copy_multipart(self, src_blob: AnyBlob, dst_blob: CloudBlob):
-        assert not isinstance(src_blob, type(dst_blob))
-        tags = copy_multipart_passthrough(src_blob, dst_blob, compute_checksums=isinstance(src_blob, LocalBlob))
-        self._async_set.put(self._finalize_copy, src_blob, dst_blob, tags)
+        self._do_copy(copy_multipart_passthrough,
+                      src_blob,
+                      dst_blob,
+                      compute_checksums=isinstance(src_blob, LocalBlob))
+
+    def _do_copy_async(self, copy_func: _CopyMethod, src_blob: AnyBlob, dst_blob: AnyBlob, *args, **kwargs):
+        self._async_set.put(self._do_copy, copy_func, src_blob, dst_blob, *args, **kwargs)
+
+    def _do_copy(self, copy_func: _CopyMethod, src_blob: AnyBlob, dst_blob: AnyBlob, *args, **kwargs):
+        try:
+            tags = copy_func(src_blob, dst_blob, *args, **kwargs)
+            self._finalize_copy(src_blob, dst_blob, tags)
+        except Exception as exception:
+            self._completed.add((src_blob, dst_blob, exception))
+            logger.error(f"Failed to copy {src_blob.url} to {dst_blob.url}"
+                         f"{os.linesep}{traceback.format_exc()}")
 
     def _finalize_copy(self, src_blob: AnyBlob, dst_blob: AnyBlob, tags: Optional[dict]=None):
         if not isinstance(dst_blob, LocalBlob):
             tags = tags or src_blob.get_tags()
             verify_checksums(src_blob.url, dst_blob, tags, self._ignore_missing_checksums)
             dst_blob.put_tags(tags)
-        self._completed_keys.add(dst_blob.key)
+        self._completed.add((src_blob, dst_blob, None))
         logger.info(f"Copied {src_blob.url} to {dst_blob.url}")
 
-    def completed(self) -> Generator[str, None, None]:
-        while self._completed_keys:
-            yield self._completed_keys.pop()
+    def completed(self) -> Generator[Tuple[AnyBlob, AnyBlob, Optional[Exception]], None, None]:
+        while self._completed:
+            src_blob, dst_blob, exception = self._completed.pop()
+            yield src_blob, dst_blob, exception
 
     def __enter__(self):
         return self
@@ -127,6 +123,15 @@ class CopyClient:
     def __exit__(self, *args, **kwargs):
         for _ in self._async_set.consume():
             pass
+
+def _download_to(src_blob: AnyBlob, dst_blob: LocalBlob) -> Dict[str, str]:
+    src_blob.download(dst_blob.url)
+    return dict()
+
+def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob) -> Dict[str, str]:
+    assert isinstance(src_blob, type(dst_blob))
+    dst_blob.copy_from(src_blob)  # type: ignore
+    return src_blob.get_tags()
 
 def verify_checksums(src_url: str,
                      dst_blob: CloudBlob,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -51,12 +51,12 @@ class TestStorage(infra.SuppressWarningsMixin, unittest.TestCase):
                 with self.subTest(blob.url):
                     self.assertEqual(blob.get(), expected_data)
 
-        # Cloud tests data is not tagged with checksums. This should raise.
-        with self.subTest("should raise"):
-            with self.assertRaises(storage.SSDSCopyError):
-                self._do_blobstore_copies((s3_blobstore, gs_blobstore),
-                                          (s3_blobstore, gs_blobstore),
-                                          ignore_missing_checksums=False)
+        # Cloud tests data is not tagged with checksums. All copies should fail.
+        with self.subTest("Copies should fail"):
+            _, completed_keys = self._do_blobstore_copies((s3_blobstore, gs_blobstore),
+                                                          (s3_blobstore, gs_blobstore),
+                                                          ignore_missing_checksums=False)
+            self.assertEqual(0, len(completed_keys))
 
     def test_copy_client_compute_checksums(self):
         expected_data_map, completed_keys = self._do_blobstore_copies((local_blobstore, s3_blobstore, gs_blobstore),
@@ -72,12 +72,12 @@ class TestStorage(infra.SuppressWarningsMixin, unittest.TestCase):
                              dst_blobstores=(local_blobstore, s3_blobstore, gs_blobstore),
                              ignore_missing_checksums=True,
                              compute_checksums=False):
-        oneshot, multipart = test_data.uploaded([local_blobstore, s3_blobstore, gs_blobstore])
+        oneshot, multipart = test_data.uploaded(src_blobstores)
         expected_data_map = dict()
         with storage.CopyClient(ignore_missing_checksums=ignore_missing_checksums) as client:
             for src_bs in src_blobstores:
                 for dst_bs in dst_blobstores:
-                    for data_bundle in (oneshot, multipart):
+                    for data_bundle in (oneshot,):
                         src_blob = src_bs.blob(data_bundle['key'])
                         dst_blob = dst_bs.blob(os.path.join(f"{uuid4()}", f"{uuid4()}"))
                         if compute_checksums:
@@ -85,7 +85,8 @@ class TestStorage(infra.SuppressWarningsMixin, unittest.TestCase):
                         else:
                             client.copy(src_blob, dst_blob)
                         expected_data_map[dst_blob] = data_bundle['data']
-        return expected_data_map, [key for key in client.completed()]
+        return expected_data_map, [dst_blob.key for src_blob, dst_blob, exc in client.completed()
+                                   if exc is None]
 
     def test_verify_checksums(self):
         tests = [(S3Blob, storage.SSDSObjectTag.SSDS_MD5),

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -72,7 +72,7 @@ class TestStorage(infra.SuppressWarningsMixin, unittest.TestCase):
                              dst_blobstores=(local_blobstore, s3_blobstore, gs_blobstore),
                              ignore_missing_checksums=True,
                              compute_checksums=False):
-        oneshot, multipart = test_data.uploaded(src_blobstores)
+        oneshot, _ = test_data.uploaded(src_blobstores)
         expected_data_map = dict()
         with storage.CopyClient(ignore_missing_checksums=ignore_missing_checksums) as client:
             for src_bs in src_blobstores:


### PR DESCRIPTION
The storage.copy_client context manager previously threw an exception upon exit if any number of copies failed, leaving some errors unreported.

This causes it to save, log, and report all copy errors.