### PR TITLE
Introduce data "release"

### DIFF
--- a/ssds/__init__.py
+++ b/ssds/__init__.py
@@ -1,9 +1,10 @@
 import os
 import sys
+import json
 import logging
-from typing import Generator, Optional, Tuple, Type, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
-from ssds import storage
+from ssds import storage, aws, gcp, utils
 from ssds.blobstore import BlobStore
 from ssds.blobstore.s3 import S3Blob, S3BlobStore
 from ssds.blobstore.gs import GSBlob, GSBlobStore
@@ -20,6 +21,7 @@ class SSDS:
     blobstore_class: Type[BlobStore]
     bucket: str
     prefix = "submissions"
+    release_prefix = "working"
     _name_delimeter = "--"  # Not using "/" as name delimeter produces friendlier `aws s3` listing
 
     def __init__(self, google_billing_project: Optional[str]=None):
@@ -156,3 +158,44 @@ def sync(submission_id: str, src: SSDS, dst: SSDS) -> Generator[str, None, None]
                 f"submission_id='{submission_id}' "
                 f"src='{src}' "
                 f"dst='{dst}'")
+
+def release(submission_id: str, src: SSDS, dst: SSDS, transfers: List[Tuple[str, str]]) -> dict:
+    # verify transfers
+    dst_keys = set()
+    src_keys = set()
+    for src_url, dst_url in transfers:
+        src_bucket, src_key = storage.parse_cloud_url(src_url)
+        dst_bucket, dst_key = storage.parse_cloud_url(dst_url)
+        assert src_bucket == src.bucket, f"Source keys must be from bucket {src.bucket}"
+        assert dst_bucket == dst.bucket, f"Destination keys must be from bucket {dst.bucket}"
+        assert src_key not in src_keys, "Duplicate source keys not allowed"
+        assert dst_key not in dst_keys, "Duplicate destination keys not allowed"
+        assert src_key.startswith(f"submissions/{submission_id}"), f"Source keys must be in submission {submission_id}"
+        assert dst_key.startswith(f"{src.release_prefix}/"), \
+               f"Destination keys must be placed into the prefix '{src.release_prefix}/'"
+        src_keys.add(src_key)
+        dst_keys.add(dst_key)
+
+    manifest: Dict[str, Any] = dict(submission_id=submission_id,
+                                    src_bucket=src.bucket,
+                                    dst_bucket=dst.bucket,
+                                    aws_identity=aws.get_identity(),
+                                    gcp_identity=gcp.get_identity(),
+                                    transfer_map=list())
+
+    # perform transfer and write manifest
+    manifest['start_timestamp'] = utils.timestamp_now()
+    with storage.CopyClient() as cc:
+        for src_url, dst_url in transfers:
+            src_blob = storage.blob_for_url(src_url)
+            dst_blob = storage.blob_for_url(dst_url)
+            if not is_synced(src_blob, dst_blob):
+                cc.copy(src_blob, dst_blob)
+    for src_blob, dst_blob, exception in cc.completed():
+        if exception is None:
+            manifest['transfer_map'].append(dict(src_key=src_blob.key, dst_key=dst_blob.key))
+    manifest['end_timestamp'] = utils.timestamp_now()
+    key = f"release-transfer-manifests/{submission_id}/transfer.{manifest['start_timestamp']}"
+    if 0 < len(manifest['transfer_map']):
+        src.blobstore.blob(key).put(json.dumps(manifest).encode("utf-8"))
+    return manifest

--- a/ssds/__init__.py
+++ b/ssds/__init__.py
@@ -161,6 +161,8 @@ def sync(submission_id: str, src: SSDS, dst: SSDS) -> Generator[str, None, None]
 
 def release(submission_id: str, src: SSDS, dst: SSDS, transfers: List[Tuple[str, str]]) -> dict:
     # verify transfers
+    submission_name = src.get_submission_name(submission_id)
+    assert submission_name is not None, f"No submission for {submission_id}"
     dst_keys = set()
     src_keys = set()
     for src_url, dst_url in transfers:
@@ -195,7 +197,10 @@ def release(submission_id: str, src: SSDS, dst: SSDS, transfers: List[Tuple[str,
         if exception is None:
             manifest['transfer_map'].append(dict(src_key=src_blob.key, dst_key=dst_blob.key))
     manifest['end_timestamp'] = utils.timestamp_now()
-    key = f"release-transfer-manifests/{submission_id}/transfer.{manifest['start_timestamp']}"
+    ssds_key = src._compose_ssds_key(submission_id,
+                                     submission_name,
+                                     f"release-transfer-manifests/{manifest['start_timestamp']}")
+    key = f"{src.prefix}/{ssds_key}"
     if 0 < len(manifest['transfer_map']):
         src.blobstore.blob(key).put(json.dumps(manifest).encode("utf-8"))
     return manifest

--- a/tests/test_ssds.py
+++ b/tests/test_ssds.py
@@ -210,8 +210,13 @@ class TestSSDS(infra.SuppressWarningsMixin, unittest.TestCase):
                         src_url = src.compose_blobstore_url(ssds_key)
                         dst_url = f"{dst.blobstore.schema}{dst.bucket}/working/{uuid4()}"
                         transfers.append((src_url, dst_url))
+                    with self.assertRaises(AssertionError):
+                        manifest = ssds.release(f"this-does-not-exist-{uuid4()}", src, dst, transfers)
                     manifest = ssds.release(submission_id, src, dst, transfers)
-                    key = f"release-transfer-manifests/{submission_id}/transfer.{manifest['start_timestamp']}"
+                    ssds_key = src._compose_ssds_key(submission_id,
+                                                     submission_name,
+                                                     f"release-transfer-manifests/{manifest['start_timestamp']}")
+                    key = f"{src.prefix}/{ssds_key}"
                     blob = src.blobstore.blob(key)
                     self.assertTrue(blob.exists())
                     self.assertEqual(manifest, json.loads(blob.get().decode("utf-8")))

--- a/tests/test_ssds.py
+++ b/tests/test_ssds.py
@@ -3,6 +3,7 @@ import io
 import os
 import sys
 import time
+import json
 import logging
 import unittest
 import tempfile
@@ -192,6 +193,37 @@ class TestSSDS(infra.SuppressWarningsMixin, unittest.TestCase):
                 with self.subTest("test no resync"):
                     synced_keys = [key for key in ssds.sync(submission_id, src, dst) if key]
                     self.assertEqual(synced_keys, list())
+
+    def test_release(self):
+        for src in (S3_SSDS, GS_SSDS):
+            submission_id = f"{uuid4()}"
+            submission_name = "this_is_a_test_submission_for_release"
+            uploaded_keys = [ssds_key for ssds_key in src.upload(self.testdir,
+                                                                 submission_id,
+                                                                 submission_name)]
+            fake_key = f"{submission_id}--{submission_name}/does-not-exit"
+            uploaded_keys.extend([fake_key])
+            for dst in (S3_SSDS, GS_SSDS):
+                with self.subTest(src=src, dst=dst):
+                    transfers = list()
+                    for ssds_key in uploaded_keys:
+                        src_url = src.compose_blobstore_url(ssds_key)
+                        dst_url = f"{dst.blobstore.schema}{dst.bucket}/working/{uuid4()}"
+                        transfers.append((src_url, dst_url))
+                    manifest = ssds.release(submission_id, src, dst, transfers)
+                    key = f"release-transfer-manifests/{submission_id}/transfer.{manifest['start_timestamp']}"
+                    blob = src.blobstore.blob(key)
+                    self.assertTrue(blob.exists())
+                    self.assertEqual(manifest, json.loads(blob.get().decode("utf-8")))
+                    sources = set(m['src_key'] for m in manifest['transfer_map'])
+                    destinations = set(m['dst_key'] for m in manifest['transfer_map'])
+                    for src_url, dst_url in transfers:
+                        if fake_key not in src_url:
+                            src_blob = ssds.storage.blob_for_url(src_url)
+                            dst_blob = ssds.storage.blob_for_url(dst_url)
+                            self.assertEqual(src_blob.get(), dst_blob.get())
+                            self.assertIn(src_blob.key, sources)
+                            self.assertIn(dst_blob.key, destinations)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This copies data from a submission into "release" areas, as defined by a
user provided transfer CSV file. Destination keys must being with the
prefix "working", but are otherwise unrestricted.

A versioned manifest of the release transfer is saved in the submission
source bucket under the key:
`release-transfer-manifests/{submission_id}/transfer.{version}`,
where "version" is a formatted datetime, e.g.  "2020-10-26T192530.137917Z"

When using the CLI, releases occur in a single deployment of the SSDS.
This means that objects are copied to a different location of the same
bucket. The Python API can be used to release objects to separate SSDS
deployments.

depends on #210 