### PR TITLE
Use old testing buckets; fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ mypy --install-types
 ```
 
 Many tests require access to test buckets listed in `ssds/deployment.py`.
+
+These buckets are in the `pangenomics` AWS account.
 Be sure to configure your S3 and GS credentials have access.
 
 ## Links

--- a/ssds/deployment.py
+++ b/ssds/deployment.py
@@ -18,7 +18,7 @@ class _GSStaging(SSDS):
 
 class _S3StagingTest(SSDS):
     blobstore_class = S3BlobStore
-    bucket = "org-hpp-ssds-staging-test-platform-dev"
+    bucket = "org-hpp-ssds-staging-test"
 
 class _GSStagingTest(SSDS):
     blobstore_class = GSBlobStore

--- a/tests/fixtures/populate.py
+++ b/tests/fixtures/populate.py
@@ -65,7 +65,7 @@ def _remote_key(d: str) -> str:
 
 @lru_cache()
 def _s3_bucket():
-    return aws.resource("s3").Bucket("org-hpp-ssds-upload-test-platform-dev")
+    return aws.resource("s3").Bucket("org-hpp-ssds-upload-test")
 
 @lru_cache()
 def _gs_bucket():

--- a/tests/test_ssds.py
+++ b/tests/test_ssds.py
@@ -180,8 +180,8 @@ class TestSSDS(infra.SuppressWarningsMixin, unittest.TestCase):
                 submission_id = f"{uuid4()}"
                 submission_name = "this_is_a_test_submission_for_sync"
                 uploaded_keys = set([ssds_key for ssds_key in src.upload(self.testdir,
-                                                                     submission_id,
-                                                                     submission_name)])
+                                                                         submission_id,
+                                                                         submission_name)])
                 synced_keys = [key[len(f"{src.prefix}/"):] for key in ssds.sync(submission_id, src, dst)]
                 self._assert_sync(src, dst, submission_id, uploaded_keys, synced_keys)
 
@@ -258,8 +258,9 @@ class NoFixturesTests(unittest.TestCase):
     def test_get_full_prefix(self):
         with unittest.mock.patch.object(S3_SSDS.blobstore, 'list') as mock_list:
             mock_list.return_value.__next__.return_value = S3Blob(
-                bucket_name='org-hpp-ssds-staging-test-platform-dev',
-                key='submissions/dc4385e0-0553-4a8b-b000-9542b7d990c3--this_is_a_test_submission_for_sync/foo/bar/bert.dat'
+                bucket_name=_S3StagingTest.bucket,
+                key='submissions/dc4385e0-0553-4a8b-b000-9542b7d990c3--'
+                    'this_is_a_test_submission_for_sync/foo/bar/bert.dat'
             )
             full_prefix = S3_SSDS.get_submission_prefix('foo')
         expected = 'submissions/dc4385e0-0553-4a8b-b000-9542b7d990c3--this_is_a_test_submission_for_sync'


### PR DESCRIPTION
We have now traced where these buckets live: they reside in the
`pangenomics` AWS account. Someone with developer access should be able
to run the tests successfully.

Once this PR is merged the replacement buckets should be deleted:

- org-hpp-ssds-staging-test-platform-dev
- org-hpp-ssds-upload-test-platform-dev